### PR TITLE
MOP-50 Add end points to activate/deactivate offences in NOMIS and record reactivations in a table - this only happens in an edge case in NOMIS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/OffenceReactivatedInNomis.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/OffenceReactivatedInNomis.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.entity
+
+import java.time.LocalDateTime
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity
+@Table
+data class OffenceReactivatedInNomis(
+  @Id
+  val offenceId: Long = -1,
+  val reactivatedByUsername: String = "",
+  val reactivatedDate: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/external/prisonapi/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/external/prisonapi/Offence.kt
@@ -11,4 +11,7 @@ data class Offence(
   val activeFlag: String,
   val listSequence: Int? = null,
   val expiryDate: LocalDate? = null,
-)
+) {
+  val isActive
+    get() = activeFlag == "Y"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceReactivatedInNomisRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceReactivatedInNomisRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.OffenceReactivatedInNomis
+
+@Repository
+interface OffenceReactivatedInNomisRepository : JpaRepository<OffenceReactivatedInNomis, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminController.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -35,6 +36,28 @@ class AdminController(
   fun getAllToggles(): List<FeatureToggle> {
     log.info("Request received to get values of all feature toggles")
     return adminService.getAllToggles()
+  }
+
+  @PostMapping(value = ["/nomis/offences/reactivate"])
+  @PreAuthorize("hasRole('ROLE_NOMIS_OFFENCE_ACTIVATOR')")
+  @Operation(
+    summary = "Reactivate offences in NOMIS",
+    description = "Reactivate offences in NOMIS, only to be used for offences that are end dated but NOMIS need them to be reactivated",
+  )
+  fun reactivateNomisOffence(@RequestBody offenceIds: List<Long>) {
+    log.info("Request received to reactivate offences in nomis")
+    return adminService.reactivateNomisOffence(offenceIds)
+  }
+
+  @PostMapping(value = ["/nomis/offences/deactivate"])
+  @PreAuthorize("hasRole('ROLE_NOMIS_OFFENCE_ACTIVATOR')")
+  @Operation(
+    summary = "Deactivate offences in NOMIS",
+    description = "Deactivate offences in NOMIS, only to be used for offences that are end dated but are active in NOMIS",
+  )
+  fun deactivateNomisOffence(@RequestBody offenceIds: List<Long>) {
+    log.info("Request received to deactivate offences in nomis")
+    return adminService.deactivateNomisOffence(offenceIds)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
@@ -2,21 +2,75 @@ package uk.gov.justice.digital.hmpps.manageoffencesapi.service
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.manageoffencesapi.config.AuthAwareAuthenticationToken
 import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.FeatureToggle
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceReactivatedInNomisRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceRepository
+import java.time.LocalDate
+import javax.persistence.EntityNotFoundException
+import javax.validation.ValidationException
 
 @Service
 class AdminService(
   private val featureToggleRepository: FeatureToggleRepository,
+  private val offenceRepository: OffenceRepository,
+  private val offenceReactivatedInNomisRepository: OffenceReactivatedInNomisRepository,
+  private val prisonApiClient: PrisonApiClient,
 ) {
   @Transactional
   fun toggleFeature(featureToggles: List<FeatureToggle>) {
     featureToggles.forEach {
       featureToggleRepository.findById(it.feature)
         .ifPresent { featureToggle -> featureToggleRepository.save(featureToggle.copy(enabled = it.enabled)) }
+    }
+  }
+
+  fun getCurrentAuthentication(): AuthAwareAuthenticationToken =
+    SecurityContextHolder.getContext().authentication as AuthAwareAuthenticationToken?
+      ?: throw IllegalStateException("User is not authenticated")
+
+  @Transactional
+  fun reactivateNomisOffence(offenceIds: List<Long>) {
+    offenceIds.forEach { offenceId ->
+      val offence = offenceRepository.findById(offenceId)
+        .orElseThrow { EntityNotFoundException("Offence with ID $offenceId not found") }
+      val nomisOffence = prisonApiClient
+        .findByOffenceCodeStartsWith(offence.code, 0)
+        .content.first { it.code == offence.code }
+
+      if (nomisOffence.isActive) {
+        throw ValidationException("Th offence flag is already set to active")
+      }
+      prisonApiClient.changeOffenceActiveFlag(offenceId, true)
+      offenceReactivatedInNomisRepository.save(transform(offenceId, getCurrentAuthentication().principal))
+    }
+  }
+
+  @Transactional
+  fun deactivateNomisOffence(offenceIds: List<Long>) {
+    offenceIds.forEach { offenceId ->
+      val offence = offenceRepository.findById(offenceId)
+        .orElseThrow { EntityNotFoundException("Offence with ID $offenceId not found") }
+      if (offence.endDate == null || offence.endDate.isAfter(LocalDate.now().minusDays(1))) {
+        throw ValidationException("This offence's end date has not yet expired - therefore cannot deactivate in NOMIS")
+      }
+      val nomisOffence = prisonApiClient
+        .findByOffenceCodeStartsWith(offence.code, 0)
+        .content.first { it.code == offence.code }
+
+      if (!nomisOffence.isActive) {
+        throw ValidationException("Th offence $offenceId is already inactive in NOMIS")
+      }
+      prisonApiClient.changeOffenceActiveFlag(offenceId, false)
+
+      if (offenceReactivatedInNomisRepository.existsById(offenceId)) {
+        offenceReactivatedInNomisRepository.deleteById(offenceId)
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/PrisonApiClient.kt
@@ -84,4 +84,9 @@ class PrisonApiClient(@Qualifier("prisonApiWebClient") private val webClient: We
       .toBodilessEntity()
       .block()
   }
+
+  fun changeOffenceActiveFlag(offenceId: Long, activeFlag: Boolean) {
+    // TODO Add call to prison API (end point neds creating in prison-api)
+    return
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/TransformFunctions.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.manageoffencesapi.service
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.FeatureToggle
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.NomisChangeHistory
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.Offence
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.OffenceReactivatedInNomis
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.OffenceScheduleMapping
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.SchedulePart
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.SdrsLoadResult
@@ -245,4 +246,9 @@ fun transform(
   paragraphTitle = linkOffence.paragraphTitle,
   lineReference = linkOffence.lineReference,
   legislationText = linkOffence.legislationText
+)
+
+fun transform(offenceId: Long, username: String) = OffenceReactivatedInNomis(
+  offenceId = offenceId,
+  reactivatedByUsername = username,
 )

--- a/src/main/resources/migration/common/V25__reactivated_in_nomis_table.sql
+++ b/src/main/resources/migration/common/V25__reactivated_in_nomis_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE offence_reactivated_in_nomis (
+    offence_id INT REFERENCES offence (id),
+    reactivated_by_username VARCHAR(32) NOT NULL,
+    reactivated_date TIMESTAMP WITH TIME ZONE  NOT NULL,
+    PRIMARY KEY (offence_id)
+);
+
+comment on table offence_reactivated_in_nomis is 'Contains offences that have been end dated (i.e. inactive) - but have been overridden to be active in NOMIS';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -73,13 +73,25 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubFindByOffenceCodeStartsWith(offenceCode: Char) {
+  fun stubFindByOffenceCodeStartsWith(offenceCode: String) {
     stubFor(
       get("/api/offences/code/$offenceCode?page=0&size=1000&sort=code,ASC").willReturn(
         aResponse()
           .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
           .withBody(
             nomisOffences
+          )
+      )
+    )
+  }
+
+  fun stubFindByOffenceCode(offenceCode: String) {
+    stubFor(
+      get("/api/offences/code/$offenceCode?page=0&size=1000&sort=code,ASC").willReturn(
+        aResponse()
+          .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+          .withBody(
+            activeNomisOffences
           )
       )
     )
@@ -205,6 +217,54 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                       },
                       "severityRanking": "700",
                       "activeFlag": "N"
+                    }
+                  ],
+                  "pageable": {
+                    "sort": {
+                      "unsorted": false,
+                      "sorted": true,
+                      "empty": false
+                    },
+                    "offset": 0,
+                    "pageNumber": 0,
+                    "pageSize": 20,
+                    "paged": true,
+                    "unpaged": false
+                  },
+                  "last": true,
+                  "totalElements": 5,
+                  "totalPages": 1,
+                  "size": 20,
+                  "number": 0,
+                  "sort": {
+                    "unsorted": false,
+                    "sorted": true,
+                    "empty": false
+                  },
+                  "first": true,
+                  "numberOfElements": 5,
+                  "empty": false
+                }
+    """.trimIndent()
+
+    private val activeNomisOffences = """ {
+                  "content": [
+                    {
+                      "code": "M5119999",
+                      "description": "Manslaughter Old",
+                      "statuteCode": {
+                        "code": "M111",
+                        "description": "Statute M111",
+                        "legislatingBodyCode": "UK",
+                        "activeFlag": "Y"
+                      },
+                      "hoCode": {
+                        "code": "815/90",
+                        "description": "Ho Code 815/90",
+                        "activeFlag": "Y"
+                      },
+                      "severityRanking": "700",
+                      "activeFlag": "Y"
                     }
                   ],
                   "pageable": {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminServiceTest.kt
@@ -10,13 +10,18 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature.FULL_SYNC_NOMIS
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.FeatureToggle
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceReactivatedInNomisRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceRepository
 import java.util.Optional
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.FeatureToggle as FeatureToggleEntity
 
 class AdminServiceTest {
   private val featureToggleRepository = mock<FeatureToggleRepository>()
+  private val offenceRepository = mock<OffenceRepository>()
+  private val offenceReactivatedInNomisRepository = mock<OffenceReactivatedInNomisRepository>()
+  private val prisonApiClient = mock<PrisonApiClient>()
 
-  private val adminService = AdminService(featureToggleRepository)
+  private val adminService = AdminService(featureToggleRepository, offenceRepository, offenceReactivatedInNomisRepository, prisonApiClient)
 
   @Test
   fun `If the feature doesnt exist then no save is performed`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceServiceIntTest.kt
@@ -23,7 +23,7 @@ class OffenceServiceIntTest : IntegrationTestBase() {
     ('A'..'Z').forEach { alphaChar ->
       prisonApiMockServer.stubFindByOffenceCodeStartsWithReturnsNothing(alphaChar)
     }
-    prisonApiMockServer.stubFindByOffenceCodeStartsWith('M')
+    prisonApiMockServer.stubFindByOffenceCodeStartsWith("M")
     prisonApiMockServer.stubCreateHomeOfficeCode()
     prisonApiMockServer.stubCreateStatute()
     prisonApiMockServer.stubCreateOffence()

--- a/src/test/resources/test_data/insert-active-and-inactive-offence.sql
+++ b/src/test/resources/test_data/insert-active-and-inactive-offence.sql
@@ -1,0 +1,7 @@
+INSERT INTO public.offence
+(code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, category, sub_category)
+VALUES('M4119999', 'Manslaughter - active', 570173, 'Manslaughter - active', '2009-11-02', NULL, '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 91, 81);
+
+INSERT INTO public.offence
+(code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, category, sub_category)
+VALUES('M5119999', 'Murder - inactive', 570173, 'Murder - inactive', '2009-11-02', '2014-11-02', '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 91, 81);

--- a/src/test/resources/test_data/insert-inactive-offence-and-reactivated.sql
+++ b/src/test/resources/test_data/insert-inactive-offence-and-reactivated.sql
@@ -1,0 +1,5 @@
+INSERT INTO offence
+(code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, category, sub_category)
+VALUES('M5119999', 'Murder - inactive', 570173, 'Murder - inactive', '2009-11-02', '2014-11-02', '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 91, 81);
+
+INSERT INTO offence_reactivated_in_nomis (offence_id, reactivated_by_username, reactivated_date) values ((select id from offence where code = 'M5119999'), 'any-user', NOW());

--- a/src/test/resources/test_data/reset-all-data.sql
+++ b/src/test/resources/test_data/reset-all-data.sql
@@ -1,3 +1,4 @@
+DELETE from offence_reactivated_in_nomis;
 DELETE from offence_schedule_mapping;
 DELETE from offence;
 DELETE from sdrs_load_result_history;


### PR DESCRIPTION
TODO 

1. Create prison-api endpoint to activate/deactivate offences
2. Integrate the new prison-api with this functionality (resolve TODO in code)