### PR TITLE
MOP-67 Only update the last_successful_load date for an sdrs cache if the call was successful (do not update on error)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSService.kt
@@ -348,7 +348,7 @@ class SDRSService(
         status = status,
         loadType = type,
         loadDate = loadDate,
-        lastSuccessfulLoadDate = if (status == SUCCESS) loadDate else null,
+        lastSuccessfulLoadDate = if (status == SUCCESS) loadDate else loadStatusExisting.lastSuccessfulLoadDate,
         nomisSyncRequired = status == SUCCESS,
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceIntTest.kt
@@ -224,6 +224,7 @@ class SDRSServiceIntTest : IntegrationTestBase() {
     val statusHistoryRecords = sdrsLoadResultHistoryRepository.findAll()
 
     assertThat(statusRecords.first { it.cache == OFFENCES_A }.status).isEqualTo(FAIL)
+    assertThat(statusRecords.first { it.cache == OFFENCES_A }.lastSuccessfulLoadDate?.toLocalDate()).isEqualTo(LocalDate.of(2022, 4, 19))
     assertThat(statusRecords.first { it.cache == OFFENCES_A }.loadType).isEqualTo(UPDATE)
     assertThat(statusHistoryRecords.first { it.cache == OFFENCES_A }.status).isEqualTo(FAIL)
     assertThat(statusHistoryRecords.first { it.cache == OFFENCES_A }.loadType).isEqualTo(UPDATE)


### PR DESCRIPTION
This is a regression bug - introduced by a previous change