### PR TITLE
MOP-75 Use 'latest version' for each record from the ho data load + switch dev to use prod sdrs service + remove constraint between reactivated_in_nomis  to offence table

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,7 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
-    API_BASE_URL_SDRS: https://crime-reference-data-api.staging.service.justice.gov.uk
+    API_BASE_URL_SDRS: https://crime-reference-data-api.service.justice.gov.uk
     API_BASE_URL_PRISON_API: https://api-dev.prison.service.justice.gov.uk
 
   # Switches off the allowlist in the DEV env only.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/OffenceReactivatedInNomis.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/OffenceReactivatedInNomis.kt
@@ -9,7 +9,6 @@ import java.time.LocalDateTime
 @Table
 data class OffenceReactivatedInNomis(
   @Id
-  val offenceId: Long = -1,
   val offenceCode: String,
   val reactivatedByUsername: String,
   val reactivatedDate: LocalDateTime = LocalDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceReactivatedInNomisRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceReactivatedInNomisRepository.kt
@@ -5,6 +5,4 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.OffenceReactivatedInNomis
 
 @Repository
-interface OffenceReactivatedInNomisRepository : JpaRepository<OffenceReactivatedInNomis, Long> {
-  fun findByOffenceCodeIn(offenceCodes: List<String>): List<OffenceReactivatedInNomis>
-}
+interface OffenceReactivatedInNomisRepository : JpaRepository<OffenceReactivatedInNomis, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceToSyncWithNomisRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceToSyncWithNomisRepository.kt
@@ -3,6 +3,9 @@ package uk.gov.justice.digital.hmpps.manageoffencesapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.OffenceToSyncWithNomis
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.NomisSyncType
 
 @Repository
-interface OffenceToSyncWithNomisRepository : JpaRepository<OffenceToSyncWithNomis, String>
+interface OffenceToSyncWithNomisRepository : JpaRepository<OffenceToSyncWithNomis, String> {
+  fun existsByOffenceCodeAndNomisSyncType(offenceCode: String, nomisSyncType: NomisSyncType): Boolean
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
@@ -69,8 +69,8 @@ class AdminService(
       }
       prisonApiUserClient.changeOffenceActiveFlag(transform(offence, false))
 
-      if (offenceReactivatedInNomisRepository.existsById(offenceId)) {
-        offenceReactivatedInNomisRepository.deleteById(offenceId)
+      if (offenceReactivatedInNomisRepository.existsById(offence.code)) {
+        offenceReactivatedInNomisRepository.deleteById(offence.code)
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceService.kt
@@ -186,7 +186,7 @@ class OffenceService(
 
     // Reactivated offences are offences that have been explicitly made active in NOMIS (using the manage-offences UI)
     // So they will remain active in NOMIS (although they have been end dated). This list will be small
-    val reactivatedOffences = reactivatedInNomisRepository.findByOffenceCodeIn(
+    val reactivatedOffences = reactivatedInNomisRepository.findAllById(
       existingOffenceKeys
         .map { it.first },
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/TransformFunctions.kt
@@ -249,7 +249,6 @@ fun transform(
 )
 
 fun transform(offence: Offence, username: String) = OffenceReactivatedInNomis(
-  offenceId = offence.id,
   offenceCode = offence.code,
   reactivatedByUsername = username,
 )

--- a/src/main/resources/migration/common/V32__offence_reactivated_in_nomis_remove_constraint.sql
+++ b/src/main/resources/migration/common/V32__offence_reactivated_in_nomis_remove_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE offence_reactivated_in_nomis DROP COLUMN offence_id;
+ALTER TABLE offence_reactivated_in_nomis ADD PRIMARY KEY (offence_code);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminControllerIntTest.kt
@@ -88,13 +88,12 @@ class AdminControllerIntTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
 
-    val reactivatedOffence = offenceReactivatedInNomisRepository.findById(offence.id).get()
+    val reactivatedOffence = offenceReactivatedInNomisRepository.findById(offence.code).get()
     assertThat(reactivatedOffence)
       .usingRecursiveComparison()
       .ignoringFieldsMatchingRegexes(".*Date")
       .isEqualTo(
         OffenceReactivatedInNomis(
-          offenceId = offence.id,
           offenceCode = offence.code,
           reactivatedByUsername = "test-client",
         ),
@@ -133,7 +132,7 @@ class AdminControllerIntTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
 
-    assertThat(offenceReactivatedInNomisRepository.findById(offence.id).isPresent).isFalse
+    assertThat(offenceReactivatedInNomisRepository.findById(offence.code).isPresent).isFalse
   }
 
   private fun getFeatureToggles(): MutableList<FeatureToggle>? =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/HoCodeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/HoCodeServiceTest.kt
@@ -150,6 +150,7 @@ class HoCodeServiceTest {
           ),
         ),
       ).thenReturn(listOf(OFFENCE_2, OFFENCE_3, OFFENCE_4))
+      whenever(offenceToSyncWithNomisRepository.existsByOffenceCodeAndNomisSyncType(OFFENCE_4.code, NomisSyncType.HO_CODE_UPDATE)).thenReturn(true)
 
       hoCodeService.fullLoadOfHomeOfficeCodes()
 
@@ -187,10 +188,6 @@ class HoCodeServiceTest {
           listOf(
             OffenceToSyncWithNomis(
               offenceCode = OFFENCE_2.code,
-              nomisSyncType = NomisSyncType.HO_CODE_UPDATE,
-            ),
-            OffenceToSyncWithNomis(
-              offenceCode = OFFENCE_4.code,
               nomisSyncType = NomisSyncType.HO_CODE_UPDATE,
             ),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/HoCodeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/HoCodeServiceTest.kt
@@ -57,7 +57,7 @@ class HoCodeServiceTest {
     }
 
     @Test
-    fun `Test that a full load runs successfully - loads ho-codes and mappings`() {
+    fun `Test that a full load runs successfully - loads latest ho-codes and mappings`() {
       whenever(adminService.isFeatureEnabled(Feature.SYNC_HOME_OFFICE_CODES)).thenReturn(true)
       whenever(awsS3Service.getSubDirectories(HO_CODES.s3BasePath)).thenReturn(SUB_DIRECTORIES_HO_CODE)
       whenever(awsS3Service.getSubDirectories(HO_CODES_TO_OFFENCE_MAPPING.s3BasePath)).thenReturn(
@@ -72,6 +72,7 @@ class HoCodeServiceTest {
       whenever(awsS3Service.loadParquetFileContents(HO_FILE_1_KEY, HO_CODES.mappingClass)).thenReturn(
         listOf(
           HOME_OFFICE_CODE_1,
+          HOME_OFFICE_CODE_1_OLD,
         ),
       )
       whenever(
@@ -79,7 +80,7 @@ class HoCodeServiceTest {
           MAPPING_FILE_1_KEY,
           HO_CODES_TO_OFFENCE_MAPPING.mappingClass,
         ),
-      ).thenReturn(listOf(MAPPING_1))
+      ).thenReturn(listOf(MAPPING_1, MAPPING_1_OLD))
 
       whenever(offenceRepository.findByCodeIn(setOf(MAPPING_1.offenceCode))).thenReturn(listOf(OFFENCE_1))
 
@@ -112,7 +113,7 @@ class HoCodeServiceTest {
   @Nested
   inner class NomisSyncTests {
     @Test
-    fun `Test that a any changes are marked to be pushed to Nomis`() {
+    fun `Test that any changes are marked to be pushed to Nomis`() {
       whenever(adminService.isFeatureEnabled(Feature.SYNC_HOME_OFFICE_CODES)).thenReturn(true)
       whenever(awsS3Service.getSubDirectories(HO_CODES.s3BasePath)).thenReturn(SUB_DIRECTORIES_HO_CODE)
       whenever(awsS3Service.getSubDirectories(HO_CODES_TO_OFFENCE_MAPPING.s3BasePath)).thenReturn(
@@ -216,11 +217,13 @@ class HoCodeServiceTest {
     val HO_FILE_1_KEY = LATEST_FOLDER_PATH_HO_CODE + "ho-code-file1"
     val MAPPING_FILE_1_KEY = LATEST_FOLDER_PATH_MAPPINGS + "mapping-file1"
 
-    val HOME_OFFICE_CODE_1 = HomeOfficeCode(code = "01234", description = "ho description 1")
-    val MAPPING_1 = HomeOfficeCodeToOffenceMapping(hoCode = "01234", offenceCode = "OFF1")
-    val MAPPING_2 = HomeOfficeCodeToOffenceMapping(hoCode = "56789", offenceCode = "OFF2")
-    val MAPPING_3 = HomeOfficeCodeToOffenceMapping(hoCode = "05678", offenceCode = "OFF3")
-    val MAPPING_4 = HomeOfficeCodeToOffenceMapping(hoCode = "99999", offenceCode = "OFF4")
+    val HOME_OFFICE_CODE_1 = HomeOfficeCode(code = "01234", description = "ho description 1", latestRecord = true)
+    val HOME_OFFICE_CODE_1_OLD = HomeOfficeCode(code = "01234", description = "ho description 1 old record", latestRecord = false)
+    val MAPPING_1 = HomeOfficeCodeToOffenceMapping(hoCode = "01234", offenceCode = "OFF1", latestRecord = true)
+    val MAPPING_2 = HomeOfficeCodeToOffenceMapping(hoCode = "56789", offenceCode = "OFF2", latestRecord = true)
+    val MAPPING_3 = HomeOfficeCodeToOffenceMapping(hoCode = "05678", offenceCode = "OFF3", latestRecord = true)
+    val MAPPING_4 = HomeOfficeCodeToOffenceMapping(hoCode = "99999", offenceCode = "OFF4", latestRecord = true)
+    val MAPPING_1_OLD = HomeOfficeCodeToOffenceMapping(hoCode = "99999", offenceCode = "OFF1", latestRecord = false)
 
     private val BASE_OFFENCE = Offence(
       code = "AABB011",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceServiceTest.kt
@@ -193,7 +193,7 @@ class OffenceServiceTest {
       )
 
       whenever(
-        reactivatedInNomisRepository.findByOffenceCodeIn(
+        reactivatedInNomisRepository.findAllById(
           listOf(
             OFFENCE_A1234AAA.code,
           ),
@@ -201,7 +201,6 @@ class OffenceServiceTest {
       ).thenReturn(
         listOf(
           OffenceReactivatedInNomis(
-            offenceId = 1,
             offenceCode = OFFENCE_A1234AAA.code,
             reactivatedByUsername = "test-user",
           ),

--- a/src/test/resources/test_data/insert-future-end-dated-offence-to-sync-with-nomis.sql
+++ b/src/test/resources/test_data/insert-future-end-dated-offence-to-sync-with-nomis.sql
@@ -1,0 +1,1 @@
+INSERT INTO offence_to_sync_with_nomis (offence_code, nomis_sync_type, created_date) values ('XX99001', 'FUTURE_END_DATED', NOW());

--- a/src/test/resources/test_data/insert-inactive-offence-and-reactivated.sql
+++ b/src/test/resources/test_data/insert-inactive-offence-and-reactivated.sql
@@ -2,4 +2,4 @@ INSERT INTO offence
 (code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, category, sub_category)
 VALUES('M5119999', 'Murder - inactive', 570173, 'Murder - inactive', '2009-11-02', '2014-11-02', '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 91, 81);
 
-INSERT INTO offence_reactivated_in_nomis (offence_id, offence_code, reactivated_by_username, reactivated_date) values ((select id from offence where code = 'M5119999'), 'M5119999', 'any-user', NOW());
+INSERT INTO offence_reactivated_in_nomis (offence_code, reactivated_by_username, reactivated_date) values ('M5119999', 'any-user', NOW());

--- a/src/test/resources/test_data/insert-offence-data-that-is-reactivated-nomis.sql
+++ b/src/test/resources/test_data/insert-offence-data-that-is-reactivated-nomis.sql
@@ -2,4 +2,4 @@ INSERT INTO offence
 (code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, category, sub_category)
 VALUES('M5119999', 'Manslaughter Updated', 570173, 'Manslaughter Updated', '2009-11-02', '2012-11-02', '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 91, 81);
 
-INSERT INTO offence_reactivated_in_nomis (offence_id, offence_code, reactivated_by_username, reactivated_date) VALUES ((SELECT id FROM offence WHERE code = 'M5119999'), 'M5119999', 'test-user', NOW());
+INSERT INTO offence_reactivated_in_nomis (offence_code, reactivated_by_username, reactivated_date) VALUES ('M5119999', 'test-user', NOW());


### PR DESCRIPTION
- The ho code data has duplicate records, only use the 'latest version' of each record
- There is a breaking change with 'staging sdrs', so temporarily switch to using 'prod sdrs' until investigated (separate ticket)
- Remove the hard link between the reactivated_in_nomis and offence tables. This is so that a full-sdrs-load doesnt have to re-create the contents of this table after a full load.