### PR TITLE
MOP-154 Create two lists for different criteria.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/SexualOrViolentLists.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/SexualOrViolentLists.kt
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Contains the list of all the offences that are sexual (Schedule 3 or 15 Part 2) or violent (Schedule 15 Part 1)")
 data class SexualOrViolentLists(
+  @Schema(description = "Offence code starts with SX03 or SX56 or is in Schedule 15, Part 2")
+  val sexualCodesAndS15P2: Set<OffenceToScheduleMapping> = emptySet(),
   @Schema(description = "Offence is in Schedule 3 or Schedule 15, Part 2")
-  val sexual: Set<OffenceToScheduleMapping> = emptySet(),
+  val sexualS3AndS15P2: Set<OffenceToScheduleMapping> = emptySet(),
   @Schema(description = "Offence is in Schedule 15, Part 1")
   val violent: Set<OffenceToScheduleMapping> = emptySet(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleController.kt
@@ -138,7 +138,7 @@ class ScheduleController(
   )
   fun getSexualOrViolentLists(): SexualOrViolentLists {
     log.info("Request received to get list of sexual or violent offences")
-    return scheduleService.getSexualOrVioletLists()
+    return scheduleService.getSexualOrViolentLists()
   }
 
   @GetMapping(value = ["/pcsc-lists"])

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleControllerIntTest.kt
@@ -175,11 +175,40 @@ class ScheduleControllerIntTest : IntegrationTestBase() {
     val loadDate = LocalDateTime.of(2022, 4, 7, 0, 0, 0)
 
     assertThat(result).usingRecursiveComparison()
-      .ignoringFieldsMatchingRegexes(".*id")
+      .ignoringFieldsMatchingRegexes(".*id|.*isChild|.*childOffences")
       .ignoringCollectionOrder()
       .isEqualTo(
         SexualOrViolentLists(
-          sexual = hashSetOf(
+          sexualCodesAndS15P2 = hashSetOf(
+            OffenceToScheduleMapping(
+              id = 3,
+              description = "Intentionally obstruct an authorised person",
+              code = "AB14002",
+              changedDate = changeDate,
+              startDate = startDate,
+              loadDate = loadDate,
+              revisionId = 574487,
+            ),
+            OffenceToScheduleMapping(
+              id = 3,
+              description = "Test for SX03 prefixed codes",
+              code = "SX03TEST",
+              changedDate = changeDate,
+              startDate = startDate,
+              loadDate = loadDate,
+              revisionId = 574450,
+            ),
+            OffenceToScheduleMapping(
+              id = 3,
+              description = "Test for SX56 prefixed codes",
+              code = "SX56TEST",
+              changedDate = changeDate,
+              startDate = startDate,
+              loadDate = loadDate,
+              revisionId = 574431,
+            ),
+          ),
+          sexualS3AndS15P2 = hashSetOf(
             OffenceToScheduleMapping(
               id = 4,
               description = "CJS Title Fail to give to an authorised person information / assistance / provide facilities that person may require",


### PR DESCRIPTION
The sexual offence criteria is now controlled by a toggle, this produces a list for each criteria to be displayed in the UI.