### PR TITLE
MOP-168 Extend period to look up offences from SDRS by 24 hours beyond the last successful load date

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/IntegrationTestBase.kt
@@ -50,6 +50,10 @@ abstract class IntegrationTestBase {
       hmppsAuthMockServer.stubGrantToken()
       prisonApiMockServer.start()
       sdrsApiMockServer.start()
+      sdrsApiMockServer.addMockServiceRequestListener { request, response ->
+        println("Request: ${request.bodyAsString}")
+        println("Response: ${response.bodyAsString}")
+      }
     }
 
     @AfterAll

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/wiremock/SDRSApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/wiremock/SDRSApiMockServer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.manageoffencesapi.integration.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.matching
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.http.HttpHeader
@@ -512,31 +513,50 @@ class SDRSApiMockServer : WireMockServer(WIREMOCK_PORT) {
         .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.MessageType == 'GetControlTable')]"))
         .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.From == 'CONSUMER_APPLICATION')]"))
         .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.To == 'SDRS_AZURE')]"))
+        .withRequestBody(
+          matchingJsonPath(
+            "$.MessageBody.GatewayOperationType.GetControlTableRequest.ChangedDateTime",
+            matching("^2022-04-18.*"),
+          ),
+        )
         .willReturn(
           aResponse()
-            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withHeader("Content-Type", "application/json")
             .withBody(
-              """ {
-                    "MessageBody":{
-                      "GatewayOperationType":{
-                        "GetControlTableResponse":{
-                          "ReferenceDataSet":[
-                            {
-                              "DataSet":"offence_A",
-                              "LastUpdate":"2022-04-05T09:17:19.823"
+              """{
+                            "MessageBody": {
+                                "GatewayOperationType": {
+                                    "GetControlTableResponse": {
+                                        "ReferenceDataSet": [
+                                            {
+                                                "DataSet": "offence_A",
+                                                "LastUpdate": "2022-04-05T09:17:19.823"
+                                            },
+                                            {
+                                                "DataSet": "offence_B",
+                                                "LastUpdate": "2022-04-05T09:16:58.595"
+                                            }
+                                        ]
+                                    }
+                                }
                             },
-                            {
-                              "DataSet":"offence_B",
-                              "LastUpdate":"2022-04-05T09:16:58.595"
+                            "MessageHeader": {
+                                "MessageID": {
+                                    "UUID": "7717d82c-9cc2-4983-acf1-0d42770e88bd",
+                                    "RelatesTo": "df2200e6-241c-4642-b391-3d53299185cd"
+                                },
+                                "TimeStamp": "2022-03-01T15:00:00Z",
+                                "MessageType": "GetControlTableResponse",
+                                "From": "SDRS_AZURE",
+                                "To": "CONSUMER_APPLICATION"
+                            },
+                            "MessageStatus": {
+                                "status": "SUCCESS",
+                                "code": " ",
+                                "reason": " ",
+                                "detail": " "
                             }
-                          ]
                         }
-                      }
-                    },                    
-                    "MessageStatus": {
-                      "status": "SUCCESS"
-                    }
-                  }
               """.trimIndent(),
             ),
         ),


### PR DESCRIPTION
Under normal running we poll SDRS every 10 minutes and ask for updates from the last successful load date (which was usually 10 minutes ago)

This change still runs every 10 minutes but asks for changes since the last successful load date + 24 hours... that is because some changes aren't coming down the line from SDRS . This should fix this edge case, drawback being that we'll receive the same update multiple times (this has no functional impact)