### PR TITLE
MOP-186 create encouragement offence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ sonar-project.properties
 
 #Helm
 **/Chart.lock
+
+#Env files
+.env

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Use the keytool command. if modifying cacerts pass in the option `-cacerts`, oth
 
 ### add cert
 The SDRS Staging api is publicly open api with root URL at  
-https://crime-reference-data-api.staging.service.justice.gov.uk  
+https://sdrs.staging.apps.hmcts.net/
 However, in order for it to work with java you have to add it to the truststore, locally this can be achieved by doing the following (using the default password of changeit):
-1. Download the cert from https://crime-reference-data-api.staging.service.justice.gov.uk using a browser or the following command:  
-`openssl s_client -servername crime-reference-data-api.staging.service.justice.gov.uk -connect crime-reference-data-api.staging.service.justice.gov.uk:443 </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' >sdrs-staging.pem`
+1. Download the cert from https://sdrs.staging.apps.hmcts.net/ using a browser or the following command:  
+`openssl s_client -servername sdrs.staging.apps.hmcts.net -connect crime-reference-data-api.staging.service.justice.gov.uk:443 </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' >sdrs-staging.pem`
 2. Then add it to the tuststore using the following command:  
 `keytool -noprompt -storepass changeit -importcert -trustcacerts -cacerts -file sdrs-staging.pem -alias sdrs_staging_cert`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@
 #
 # To stop the dps-gradle-spring-boot project from overwriting any project specific customisations here, remove the
 # warning at the top of this file.
-kotlin.incremental.useClasspathSnapshot=false

--- a/run-local.sh
+++ b/run-local.sh
@@ -24,8 +24,8 @@ export AWS_REGION=eu-west-1
 # Match with ports defined in docker-compose.yml
 # export HMPPS_AUTH_URL=http://localhost:9090/auth
 export HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
-export API_BASE_URL_PRISON_API=https://api-dev.prison.service.justice.gov.uk
-export API_BASE_URL_SDRS=https://crime-reference-data-api.staging.service.justice.gov.uk
+export API_BASE_URL_PRISON_API=https://prison-api-dev.prison.service.justice.gov.uk
+export API_BASE_URL_SDRS=https://sdrs.staging.apps.hmcts.net/
 
 # Make the connection without specifying the sslmode=verify-full requirement
 export SPRING_DATASOURCE_URL='jdbc:postgresql://${DB_SERVER}/${DB_NAME}'

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminController.kt
@@ -6,12 +6,14 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.FeatureToggle
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.Offence
 import uk.gov.justice.digital.hmpps.manageoffencesapi.service.AdminService
 
 @RestController
@@ -58,6 +60,17 @@ class AdminController(
   fun deactivateNomisOffence(@RequestBody offenceIds: List<Long>) {
     log.info("Request received to deactivate offences in nomis")
     return adminService.deactivateNomisOffence(offenceIds)
+  }
+
+  @PostMapping(value = ["/nomis/offences/encouragement/{offenceId}"])
+  @PreAuthorize("hasRole('ROLE_NOMIS_OFFENCE_ACTIVATOR')")
+  @Operation(
+    summary = "Create encouragement offence for parent offence",
+    description = "Encouragement offence creates a new record with existing parent offence value, but with 'E' suffix to the offence code",
+  )
+  fun createEncouragementOffence(@PathVariable offenceId: Long): Offence {
+    log.info("Create encouragement offence for parent offence")
+    return adminService.createEncouragementOffence(offenceId)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminController.kt
@@ -62,15 +62,15 @@ class AdminController(
     return adminService.deactivateNomisOffence(offenceIds)
   }
 
-  @PostMapping(value = ["/nomis/offences/encouragement/{offenceId}"])
+  @PostMapping(value = ["/nomis/offences/encouragement/{parentOffenceId}"])
   @PreAuthorize("hasRole('ROLE_NOMIS_OFFENCE_ACTIVATOR')")
   @Operation(
     summary = "Create encouragement offence for parent offence",
     description = "Encouragement offence creates a new record with existing parent offence value, but with 'E' suffix to the offence code",
   )
-  fun createEncouragementOffence(@PathVariable offenceId: Long): Offence {
+  fun createEncouragementOffence(@PathVariable parentOffenceId: Long): Offence {
     log.info("Create encouragement offence for parent offence")
-    return adminService.createEncouragementOffence(offenceId)
+    return adminService.createEncouragementOffence(parentOffenceId)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
@@ -88,7 +88,8 @@ class AdminService(
     val offence = offenceRepository.findById(parentOffenceId)
       .orElseThrow { EntityNotFoundException("Offence not found with ID $parentOffenceId") }
 
-    if (offence.parentCode !== null && offence.parentCode == offence.code) {
+    // Parent offence should have no parentCode, or parentCode must be the same as the current Offence (indicating the parent)
+    if (offence.parentCode !== null && offence.parentCode !== offence.code) {
       throw ValidationException("Offence must be a valid parent")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
@@ -115,6 +115,7 @@ class AdminService(
 
     val encouragementOffence = offence.copy(
       id = -1,
+      parentOffenceId = offence.id,
       code = encouragementCode,
       createdDate = now,
       lastUpdatedDate = now,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRe
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceReactivatedInNomisRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceRepository
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 class AdminService(
@@ -110,9 +111,14 @@ class AdminService(
       throw ValidationException("No prison record was found for offence code ${offence.code}")
     }
 
+    val now = LocalDateTime.now()
+
     val encouragementOffence = offence.copy(
       id = -1,
       code = encouragementCode,
+      createdDate = now,
+      lastUpdatedDate = now,
+      changedDate = now,
       description = "Encouragement to ${offence.description}",
       cjsTitle = "Encouragement to ${offence.cjsTitle}",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminServiceTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature.FULL_SYNC_NOMIS
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.FeatureToggle
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.EventToRaiseRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceReactivatedInNomisRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceRepository
@@ -21,6 +22,7 @@ class AdminServiceTest {
   private val offenceReactivatedInNomisRepository = mock<OffenceReactivatedInNomisRepository>()
   private val prisonApiClient = mock<PrisonApiClient>()
   private val prisonApiUserClient = mock<PrisonApiUserClient>()
+  private val eventToRaiseRepository = mock<EventToRaiseRepository>()
 
   private val adminService = AdminService(
     featureToggleRepository,
@@ -28,6 +30,7 @@ class AdminServiceTest {
     offenceReactivatedInNomisRepository,
     prisonApiClient,
     prisonApiUserClient,
+    eventToRaiseRepository,
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminServiceTest.kt
@@ -1,18 +1,31 @@
 package uk.gov.justice.digital.hmpps.manageoffencesapi.service
 
+import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil
+import jakarta.validation.ValidationException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.EventToRaise
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.Offence
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.EventType
 import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature.FULL_SYNC_NOMIS
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.SdrsCache.OFFENCES_A
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.FeatureToggle
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.RestResponsePage
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.prisonapi.Statute
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.EventToRaiseRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceReactivatedInNomisRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.Optional
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.FeatureToggle as FeatureToggleEntity
 
@@ -66,5 +79,145 @@ class AdminServiceTest {
     val res = adminService.getAllToggles()
 
     assertThat(res).isEqualTo(listOf(FeatureToggle(FULL_SYNC_NOMIS, false)))
+  }
+
+  @Test
+  fun `Create valid Encouragement offence`() {
+    whenever(offenceRepository.findById(10)).thenReturn(Optional.of(PARENT_OFFENCE))
+    whenever(offenceRepository.findByParentOffenceId(10)).thenReturn(listOf(CHILD_OFFENCE_ONE, CHILD_OFFENCE_TWO))
+    whenever(prisonApiClient.findByOffenceCodeStartsWith(PARENT_OFFENCE.code, 0)).thenReturn(
+      createPrisonApiOffencesResponse(1, listOf(NOMIS_OFFENCE_AABB010)),
+    )
+
+    val encouragementCode = PARENT_OFFENCE.code + 'E'
+    val encouragementCjsDesc = "Encouragement to ${PARENT_OFFENCE.description}"
+
+    val savedOffence = PARENT_OFFENCE.copy(
+      id = 999,
+      code = encouragementCode,
+      description = encouragementCjsDesc,
+      cjsTitle = "Encouragement to ${PARENT_OFFENCE.cjsTitle}",
+    )
+
+    whenever(offenceRepository.save(any())).thenReturn(savedOffence)
+    doNothing().`when`(prisonApiClient).createOffences(any())
+
+    val res = adminService.createEncouragementOffence(10)
+
+    verify(prisonApiClient).createOffences(
+      listOf(
+        NOMIS_OFFENCE_AABB010.copy(
+          code = encouragementCode,
+          description = encouragementCjsDesc,
+        ),
+      ),
+    )
+
+    verify(eventToRaiseRepository).save(
+      EventToRaise(
+        offenceCode = PARENT_OFFENCE.code + 'E',
+        eventType = EventType.OFFENCE_CHANGED,
+      ),
+    )
+
+    assertThat(res).isEqualTo(
+      transform(savedOffence, childOffenceIds = listOf()),
+    )
+  }
+
+  @Test
+  fun `Encouragement offence request with existing Encouragement offence should fail`() {
+    val encouragementCode = PARENT_OFFENCE.code + 'E'
+    whenever(offenceRepository.findById(10)).thenReturn(Optional.of(PARENT_OFFENCE))
+    whenever(offenceRepository.findByParentOffenceId(10)).thenReturn(
+      listOf(
+        CHILD_OFFENCE_ONE.copy(
+          code = encouragementCode,
+        ),
+        CHILD_OFFENCE_TWO,
+      ),
+    )
+
+    assertThatThrownBy {
+      adminService.createEncouragementOffence(10)
+    }.isInstanceOf(ValidationException::class.java)
+      .hasMessage("Encouragement offence already exists for offence code $encouragementCode")
+  }
+
+  @Test
+  fun `Encouragement offence request with end date prior to 2008-02-15 should fail`() {
+    val cutOffDate = LocalDate.parse("2008-02-15")
+    whenever(offenceRepository.findById(10)).thenReturn(
+      Optional.of(
+        PARENT_OFFENCE.copy(endDate = LocalDate.parse("2008-02-14")),
+      ),
+    )
+
+    assertThatThrownBy {
+      adminService.createEncouragementOffence(10)
+    }.isInstanceOf(ValidationException::class.java)
+      .hasMessage("Offence must have an end date post $cutOffDate")
+  }
+
+  @Test
+  fun `Encouragement offence request with no Prison API record should fail`() {
+    whenever(offenceRepository.findById(10)).thenReturn(Optional.of(PARENT_OFFENCE))
+    whenever(offenceRepository.findByParentOffenceId(10)).thenReturn(listOf(CHILD_OFFENCE_ONE, CHILD_OFFENCE_TWO))
+    whenever(prisonApiClient.findByOffenceCodeStartsWith(PARENT_OFFENCE.code, 0)).thenReturn(
+      createPrisonApiOffencesResponse(0, listOf()),
+    )
+    assertThatThrownBy {
+      adminService.createEncouragementOffence(10)
+    }.isInstanceOf(ValidationException::class.java)
+      .hasMessage("No prison record was found for offence code ${PARENT_OFFENCE.code}")
+  }
+
+  private fun createPrisonApiOffencesResponse(
+    totalPages: Int,
+    content: List<uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.prisonapi.Offence>,
+  ): RestResponsePage<uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.prisonapi.Offence> =
+    RestResponsePage(
+      content = content,
+      number = 1,
+      size = 1,
+      totalElements = 0L,
+      pageable = JacksonUtil.toJsonNode("{}"),
+      last = true,
+      totalPages = totalPages,
+      sort = JacksonUtil.toJsonNode("{}"),
+      first = true,
+      numberOfElements = 0,
+    )
+
+  companion object {
+    private val PARENT_OFFENCE = Offence(
+      id = 10,
+      parentOffenceId = 10,
+      code = "AABB010",
+      description = "Desc",
+      cjsTitle = "Cjs title",
+      changedDate = LocalDateTime.now(),
+      revisionId = 1,
+      startDate = LocalDate.now(),
+      endDate = LocalDate.parse("2028-01-01"),
+      sdrsCache = OFFENCES_A,
+    )
+    private val CHILD_OFFENCE_ONE = PARENT_OFFENCE.copy(
+      id = 11,
+      code = "AABB011",
+      parentOffenceId = 10,
+    )
+    private val CHILD_OFFENCE_TWO = PARENT_OFFENCE.copy(
+      id = 12,
+      code = "AABB012",
+      parentOffenceId = 10,
+    )
+    private val NOMIS_OFFENCE_AABB010 = uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.prisonapi.Offence(
+      code = "AABB010",
+      description = "Parent Desc",
+      statuteCode = Statute(code = "A123", description = "Statute desc", activeFlag = "Y", legislatingBodyCode = "UK"),
+      severityRanking = "99",
+      activeFlag = "Y",
+    )
   }
 }


### PR DESCRIPTION
Add Admin endpoint for creating Enforcement Offence. New offence must be linked to a valid parent offence.

Only one Encouragement offence should be included per parent offence.

Encouragement offences are not valid for any offence with an end date prior to 2008-02-15.