### PR TITLE
MOP-126 Ensure children are linked to parent when added via SDRS sync

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSService.kt
@@ -62,6 +62,7 @@ class SDRSService(
   private val offenceToSyncWithNomisRepository: OffenceToSyncWithNomisRepository,
   private val eventToRaiseRepository: EventToRaiseRepository,
   private val adminService: AdminService,
+  private val scheduleService: ScheduleService,
 ) {
 
   @Scheduled(cron = "0 0 */1 * * *")
@@ -147,6 +148,7 @@ class SDRSService(
       .forEach { child ->
         offenceRepository.findOneByCode(child.parentCode!!).ifPresent { parent ->
           offenceRepository.save(child.copy(parentOffenceId = parent.id))
+          scheduleService.linkOffenceToParentSchedules(child)
         }
       }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceTest.kt
@@ -46,6 +46,7 @@ class SDRSServiceTest {
   private val eventToRaiseRepository = mock<EventToRaiseRepository>()
   private val adminService = mock<AdminService>()
   private val sdrsApiClient = mock<SDRSApiClient>()
+  private val scheduleService = mock<ScheduleService>()
 
   private val sdrsService = SDRSService(
     sdrsApiClient,
@@ -57,6 +58,7 @@ class SDRSServiceTest {
     offenceToSyncWithNomisRepository,
     eventToRaiseRepository,
     adminService,
+    scheduleService
   )
 
   @BeforeEach
@@ -120,6 +122,7 @@ class SDRSServiceTest {
     sdrsService.deltaSynchroniseWithSdrs()
 
     verify(offenceRepository, times(1)).save(OFFENCE_B123AA6A.copy(parentOffenceId = OFFENCE_B123AA6.id))
+    verify(scheduleService, times(1)).linkOffenceToParentSchedules(OFFENCE_B123AA6A)
   }
 
   @Test


### PR DESCRIPTION
* Update SDRSService to call the newly added method to copy all parent schedule mappings to the child