### PR TITLE
CRS-2412 Implement more granular caching for endpoints used by CRDS.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/config/CacheConfiguration.kt
@@ -21,28 +21,26 @@ class CacheConfiguration {
   @Bean
   fun cacheManager(): CacheManager = ConcurrentMapCacheManager(
     PCSC_LISTS,
-    PCSC_MARKERS,
     SDS_EARLY_RELEASE_EXCLUSION_LISTS,
-    SDS_EARLY_RELEASE_EXCLUSIONS,
     TORERA_OFFENCE_CODES,
     SCHEDULE_19ZA_OFFENCES,
     OFFENCE_CODE_TO_HOME_OFFICE_CODE,
+    SCHEDULE_DATA,
   )
 
   @CacheEvict(
     allEntries = true,
-    cacheNames = [PCSC_LISTS, PCSC_MARKERS, SDS_EARLY_RELEASE_EXCLUSION_LISTS, SDS_EARLY_RELEASE_EXCLUSIONS, TORERA_OFFENCE_CODES],
+    cacheNames = [PCSC_LISTS, SDS_EARLY_RELEASE_EXCLUSION_LISTS, TORERA_OFFENCE_CODES, SCHEDULE_DATA],
   )
   @Scheduled(fixedDelay = 2, timeUnit = HOURS)
   fun cacheEvict() {
     log.info(
-      "Evicting caches: {}, {}, {}, {}, {}, {}",
+      "Evicting caches: {}, {}, {}, {}, {}",
       PCSC_LISTS,
-      PCSC_MARKERS,
       SDS_EARLY_RELEASE_EXCLUSION_LISTS,
-      SDS_EARLY_RELEASE_EXCLUSIONS,
       TORERA_OFFENCE_CODES,
       SCHEDULE_19ZA_OFFENCES,
+      SCHEDULE_DATA,
     )
   }
 
@@ -58,11 +56,10 @@ class CacheConfiguration {
   companion object {
     val log: Logger = LoggerFactory.getLogger(CacheConfiguration::class.java)
     const val PCSC_LISTS: String = "pcscLists"
-    const val PCSC_MARKERS: String = "pcscMarkers"
     const val SDS_EARLY_RELEASE_EXCLUSION_LISTS: String = "sdsEarlyReleaseExclusionLists"
-    const val SDS_EARLY_RELEASE_EXCLUSIONS: String = "sdsEarlyReleaseExclusions"
     const val TORERA_OFFENCE_CODES: String = "toreraOffenceCodes"
     const val SCHEDULE_19ZA_OFFENCES: String = "schedule19ZaOffences"
     const val OFFENCE_CODE_TO_HOME_OFFICE_CODE: String = "offenceCodesToHomeOfficeCode"
+    const val SCHEDULE_DATA: String = "scheduleData"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/CachedScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/CachedScheduleService.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.service
+
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.manageoffencesapi.config.CacheConfiguration.Companion.SCHEDULE_DATA
+import java.time.LocalDate
+
+@Service
+class CachedScheduleService(
+  private val scheduleService: ScheduleService,
+) {
+
+  @Cacheable(SCHEDULE_DATA, key = "'master'")
+  @Transactional(readOnly = true)
+  fun getCachedScheduleInformation(): CachedScheduleInformation {
+    val (part1Mappings, part2Mappings) = scheduleService.getSchedule15Mappings()
+    val (domesticViolenceMappings, trancheThreeViolenceMappings) = scheduleService.getDomesticViolenceScheduleMappings()
+    val securityOffencesFromLegislation = scheduleService.getSecurityOffencesLegislation()
+    val sexualOffencesFromLegislation = scheduleService.getSexOffencesLegislation()
+    val terrorismMapping = scheduleService.getTerrorismScheduleMappings()
+    val (sexScheduleMappings, trancheThreeSexScheduleMappings) = scheduleService.getSexScheduleMappings()
+    val tranceThreeMurderMappings = scheduleService.getTrancheThreeMurderScheduleMappings()
+
+    val (part1LifeMappings, part2LifeMappings, seriousViolentOffenceMappings) = scheduleService.getSchedule15PcscMappings()
+
+    return CachedScheduleInformation(
+      part1Mappings.map { it.offence.code }.toSet(),
+      part2Mappings.map { it.offence.code }.toSet(),
+      domesticViolenceMappings.map { it.offence.code }.toSet(),
+      trancheThreeViolenceMappings.map { it.offence.code }.toSet(),
+      securityOffencesFromLegislation.map { it.code }.toSet(),
+      sexualOffencesFromLegislation.map { it.code }.toSet(),
+      terrorismMapping.map { it.offence.code }.toSet(),
+      sexScheduleMappings.map { it.offence.code }.toSet(),
+      trancheThreeSexScheduleMappings.map { it.offence.code }.toSet(),
+      tranceThreeMurderMappings.map { it.offence.code }.toSet(),
+      part1LifeMappings.map { OffenceAndStartDate(it.offence.code, it.offence.startDate) }.toSet(),
+      part2LifeMappings.map { OffenceAndStartDate(it.offence.code, it.offence.startDate) }.toSet(),
+      seriousViolentOffenceMappings.map { OffenceAndStartDate(it.offence.code, it.offence.startDate) }.toSet(),
+    )
+  }
+}
+
+data class CachedScheduleInformation(
+  val part1Mappings: Set<String>,
+  val part2Mappings: Set<String>,
+  val domesticViolenceMappings: Set<String>,
+  val trancheThreeViolenceMappings: Set<String>,
+  val securityOffencesFromLegislation: Set<String>,
+  val sexualOffencesFromLegislation: Set<String>,
+  val terrorismMapping: Set<String>,
+  val sexScheduleMappings: Set<String>,
+  val trancheThreeSexScheduleMappings: Set<String>,
+  val tranceThreeMurderMappings: Set<String>,
+  val part1LifeMappings: Set<OffenceAndStartDate>,
+  val part2LifeMappings: Set<OffenceAndStartDate>,
+  val seriousViolentOffenceMappings: Set<OffenceAndStartDate>,
+)
+
+data class OffenceAndStartDate(
+  val code: String,
+  val startDate: LocalDate,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleService.kt
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature.T3_OFFENCE_EXCLUSIONS
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffencePcscMarkers
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusion
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusion.Companion.getSdsExclusionIndicator
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscMarkers
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.ScheduleInfo
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
+import java.time.LocalDate
+
+@Service
+class IsOffenceInScheduleService(
+  private val featureToggleRepository: FeatureToggleRepository,
+  private val cachedScheduleService: CachedScheduleService,
+) {
+
+  fun findPcscMarkers(offenceCodes: List<String>): List<OffencePcscMarkers> {
+    log.info("Determining PCSC schedules for passed in offences")
+    return getOffencePcscMarkers(offenceCodes)
+  }
+  fun categoriseSdsExclusionsOffences(offenceCodes: List<String>): List<OffenceSdsExclusion> {
+    log.info("Determining Sexual or Violent status for passed in offences")
+    return getSdsExclusionIndicators(offenceCodes)
+  }
+
+  private fun getSdsExclusionIndicators(offenceCodes: List<String>): List<OffenceSdsExclusion> {
+    val scheduleInfo = cachedScheduleService.getCachedScheduleInformation()
+    val includeTrancheThree = trancheThreeEnabled()
+
+    return offenceCodes.map { offenceCode ->
+      val isSexual = scheduleInfo.part2Mappings.contains(offenceCode) ||
+        hasSexualCodePrefix(offenceCode) ||
+        scheduleInfo.sexualOffencesFromLegislation.contains(offenceCode) ||
+        scheduleInfo.sexScheduleMappings.contains(offenceCode)
+
+      val isSexualTranche3 =
+        includeTrancheThree && scheduleInfo.trancheThreeSexScheduleMappings.contains(offenceCode)
+      val isDomesticViolenceTranche3 =
+        includeTrancheThree && scheduleInfo.trancheThreeViolenceMappings.contains(offenceCode)
+      val isMurderTranche3 = includeTrancheThree && scheduleInfo.tranceThreeMurderMappings.contains(offenceCode)
+
+      val isDomesticViolence = scheduleInfo.domesticViolenceMappings.contains(offenceCode)
+      val isNationalSecurity = scheduleInfo.securityOffencesFromLegislation.contains(offenceCode)
+      val isViolent = scheduleInfo.part1Mappings.contains(offenceCode)
+      val isTerrorism = scheduleInfo.terrorismMapping.contains(offenceCode)
+
+      val indicator = getSdsExclusionIndicator(
+        isSexual,
+        isDomesticViolence,
+        isNationalSecurity,
+        isTerrorism,
+        isViolent,
+        isDomesticViolenceTranche3,
+        isSexualTranche3,
+        isMurderTranche3,
+      )
+
+      OffenceSdsExclusion(
+        offenceCode = offenceCode,
+        schedulePart = indicator,
+      )
+    }
+  }
+
+  private fun hasSexualCodePrefix(offenceCode: String): Boolean = SEXUAL_CODES_FOR_EXCLUSION_LIST.any { offenceCode.startsWith(it) }
+
+  private fun getOffencePcscMarkers(offenceCodes: List<String>): List<OffencePcscMarkers> {
+    val scheduleInfo = cachedScheduleService.getCachedScheduleInformation()
+
+    return offenceCodes.map {
+      OffencePcscMarkers(
+        offenceCode = it,
+        PcscMarkers(
+          inListA = inListA(scheduleInfo.part1LifeMappings, scheduleInfo.part2LifeMappings, it),
+          inListB = inListB(scheduleInfo.seriousViolentOffenceMappings, scheduleInfo.part2LifeMappings, it),
+          inListC = inListC(scheduleInfo.seriousViolentOffenceMappings, scheduleInfo.part2LifeMappings, it),
+          inListD = inListD(scheduleInfo.part1LifeMappings, scheduleInfo.part2LifeMappings, it),
+        ),
+      )
+    }
+  }
+
+  // List A: Schedule 15 Part 1 + Schedule 15 Part 2 that attract life (exclude all offences that start on or after 28 June 2022)
+// NOMIS SCHEDULE_15_ATTRACTS_LIFE - SDS >7 years between 01 April 2020 and 28 June 2022
+  private fun inListA(
+    part1LifeMappings: Set<OffenceAndStartDate>,
+    part2LifeMappings: Set<OffenceAndStartDate>,
+    offenceCode: String,
+  ): Boolean = part1LifeMappings.any { p -> offenceCode == p.code && p.startDate < SDS_LIST_A_CUT_OFF_DATE } ||
+    part2LifeMappings.any { p ->
+      offenceCode == p.code && p.startDate < SDS_LIST_A_CUT_OFF_DATE
+    }
+
+  // List B: Schedule 15 Part 2 that attract life + serious violent offences (same as List C)
+// NOMIS - PCSC_SDS - SDS between 4 and 7 years
+  private fun inListB(
+    seriousViolentOffenceMappings: Set<OffenceAndStartDate>,
+    part2LifeMappings: Set<OffenceAndStartDate>,
+    offenceCode: String,
+  ) = seriousViolentOffenceMappings.any { p -> offenceCode == p.code } || part2LifeMappings.any { p -> offenceCode == p.code }
+
+  // List C: Schedule 15 Part 2 that attract life + serious violent offences (same as List B)
+// NOMIS - PCSC_SEC_250 - Sec250 >7 years
+  private fun inListC(
+    seriousViolentOffenceMappings: Set<OffenceAndStartDate>,
+    part2LifeMappings: Set<OffenceAndStartDate>,
+    offenceCode: String,
+  ) = seriousViolentOffenceMappings.any { p -> offenceCode == p.code } || part2LifeMappings.any { p -> offenceCode == p.code }
+
+  // List D: Schedule 15 Part 1 + Schedule 15 Part 2 that attract life
+// NOMIS - PCSC_SDS_PLUS
+  private fun inListD(
+    part1LifeMappings: Set<OffenceAndStartDate>,
+    part2LifeMappings: Set<OffenceAndStartDate>,
+    offenceCode: String,
+  ) = part1LifeMappings.any { p -> offenceCode == p.code } || part2LifeMappings.any { p -> offenceCode == p.code }
+
+  private fun trancheThreeEnabled() = featureToggleRepository.findById(T3_OFFENCE_EXCLUSIONS).map { it.enabled }.orElse(false)
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+    val SDS_LIST_A_CUT_OFF_DATE: LocalDate = LocalDate.of(2022, 6, 28)
+
+    val SEXUAL_CODES_FOR_EXCLUSION_LIST = listOf("SX03", "SX56")
+
+    val SCHEDULE_15 = ScheduleInfo(
+      act = "Criminal Justice Act 2003",
+      code = "15",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/IntegrationTestBase.kt
@@ -13,6 +13,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.S3Client
+import uk.gov.justice.digital.hmpps.manageoffencesapi.config.CacheConfiguration
 import uk.gov.justice.digital.hmpps.manageoffencesapi.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.manageoffencesapi.integration.container.PostgresContainer
 import uk.gov.justice.digital.hmpps.manageoffencesapi.integration.wiremock.HmppsAuthMockServer
@@ -28,6 +29,9 @@ abstract class IntegrationTestBase {
   lateinit var webTestClient: WebTestClient
 
   @Autowired
+  lateinit var cacheConfiguration: CacheConfiguration
+
+  @Autowired
   lateinit var jwtAuthHelper: JwtAuthHelper
 
   @MockitoBean
@@ -35,6 +39,10 @@ abstract class IntegrationTestBase {
 
   @MockitoBean
   lateinit var s3AsyncClient: S3AsyncClient
+
+  protected fun resetCache() {
+    cacheConfiguration.cacheEvict()
+  }
 
   companion object {
     @JvmField

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleControllerIntTest.kt
@@ -69,6 +69,7 @@ class ScheduleControllerIntTest : IntegrationTestBase() {
     "classpath:test_data/insert-offence-data-pcsc.sql",
   )
   fun `Get PCSC indicators for multiple offences by offence codes`() {
+    resetCache()
     val result = webTestClient.get().uri("/schedule/pcsc-indicators?offenceCodes=AB14001,AB14002")
       .headers(setAuthorisation())
       .exchange()
@@ -108,6 +109,7 @@ class ScheduleControllerIntTest : IntegrationTestBase() {
     "classpath:test_data/insert-offence-data-sds-exclusions.sql",
   )
   fun `Get early release exclusion indicators for multiple offences by offence codes`() {
+    resetCache()
     val result = webTestClient.get()
       .uri("/schedule/sds-early-release-exclusions?offenceCodes=AB14001,AB14002,AB14003,AF06999,SX03TEST,SX56TEST,SXLEGIS,DV00001,NSLEGIS,TR00001")
       .headers(setAuthorisation())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleServiceTest.kt
@@ -1,0 +1,194 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.manageoffencesapi.config.CacheConfiguration
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.Offence
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.OffenceScheduleMapping
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.Schedule
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.SchedulePart
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.SdrsCache
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffencePcscMarkers
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscMarkers
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.NomisScheduleMappingRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceScheduleMappingRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceToSyncWithNomisRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.SchedulePartRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.ScheduleRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class IsOffenceInScheduleServiceTest {
+
+  private val scheduleRepository = mock<ScheduleRepository>()
+  private val schedulePartRepository = mock<SchedulePartRepository>()
+  private val offenceScheduleMappingRepository = mock<OffenceScheduleMappingRepository>()
+  private val offenceRepository = mock<OffenceRepository>()
+  private val featureToggleRepository = mock<FeatureToggleRepository>()
+  private val nomisScheduleMappingRepository = mock<NomisScheduleMappingRepository>()
+  private val prisonApiUserClient = mock<PrisonApiUserClient>()
+  private val prisonApiClient = mock<PrisonApiClient>()
+  private val offenceToSyncWithNomisRepository = mock<OffenceToSyncWithNomisRepository>()
+  private val adminService = mock<AdminService>()
+  private val cacheConfiguration = mock<CacheConfiguration>()
+
+  private val scheduleService =
+    ScheduleService(
+      scheduleRepository,
+      schedulePartRepository,
+      offenceScheduleMappingRepository,
+      offenceRepository,
+      featureToggleRepository,
+      prisonApiUserClient,
+      prisonApiClient,
+      nomisScheduleMappingRepository,
+      offenceToSyncWithNomisRepository,
+      adminService,
+      cacheConfiguration,
+    )
+
+  private val cachedScheduleService = CachedScheduleService(scheduleService)
+  private val isOffenceInScheduleService = IsOffenceInScheduleService(featureToggleRepository, cachedScheduleService)
+
+  @Nested
+  inner class PcscTests {
+    @Test
+    fun `Determine PCSC offences when all indicators are false`() {
+      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15.id)).thenReturn(
+        listOf(
+          SCHEDULE_15_PART_1,
+          SCHEDULE_15_PART_2,
+        ),
+      )
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          "Criminal Justice Act 2003",
+          "15",
+        ),
+      ).thenReturn(
+        emptyList(),
+      )
+
+      val res = isOffenceInScheduleService.findPcscMarkers(listOf(BASE_OFFENCE.code))
+
+      assertThat(res).isEqualTo(
+        listOf(
+          OffencePcscMarkers(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = false,
+              inListB = false,
+              inListC = false,
+              inListD = false,
+            ),
+          ),
+        ),
+      )
+    }
+
+    @Test
+    fun `Determine PCSC offences when all indicators are true`() {
+      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15.id)).thenReturn(
+        listOf(
+          SCHEDULE_15_PART_1,
+          SCHEDULE_15_PART_2,
+        ),
+      )
+
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          "Criminal Justice Act 2003",
+          "15",
+        ),
+      ).thenReturn(
+        listOf(
+          OFFENCE_SCHEDULE_MAPPING_S15_P1_LIFE,
+        ),
+      )
+
+      val res = isOffenceInScheduleService.findPcscMarkers(listOf(BASE_OFFENCE.code))
+
+      assertThat(res).isEqualTo(
+        listOf(
+          OffencePcscMarkers(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = true,
+              inListB = true,
+              inListC = true,
+              inListD = true,
+            ),
+          ),
+        ),
+      )
+    }
+
+    @Test
+    fun `Determine PCSC offences with a mix of indicators true and false`() {
+      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15.id)).thenReturn(
+        listOf(
+          SCHEDULE_15_PART_1,
+          SCHEDULE_15_PART_2,
+        ),
+      )
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          "Criminal Justice Act 2003",
+          "15",
+        ),
+      ).thenReturn(
+        listOf(
+          OFFENCE_SCHEDULE_MAPPING_S15_P1_LIFE_AFTER_CUTOFF,
+        ),
+      )
+
+      val res = isOffenceInScheduleService.findPcscMarkers(listOf(BASE_OFFENCE.code))
+
+      assertThat(res).isEqualTo(
+        listOf(
+          OffencePcscMarkers(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = false,
+              inListB = true,
+              inListC = true,
+              inListD = true,
+            ),
+          ),
+        ),
+      )
+    }
+  }
+
+  companion object {
+    private const val SCHEDULE_PART_ID_92 = 92L
+    private const val SCHEDULE_PART_ID_93 = 93L
+    private val SCHEDULE_15 = Schedule(code = "15", id = 15, act = "Act", url = "url")
+    private val SCHEDULE_15_PART_1 = SchedulePart(id = SCHEDULE_PART_ID_92, partNumber = 1, schedule = SCHEDULE_15)
+    private val SCHEDULE_15_PART_2 = SchedulePart(id = SCHEDULE_PART_ID_93, partNumber = 2, schedule = SCHEDULE_15)
+
+    private val BASE_OFFENCE = Offence(
+      code = "AABB011",
+      changedDate = LocalDateTime.now(),
+      revisionId = 1,
+      startDate = LocalDate.now(),
+      sdrsCache = SdrsCache.OFFENCES_A,
+    )
+    val BEFORE_SDS_LIST_A_CUT_OFF_DATE = LocalDate.of(2022, 6, 27)
+    private val OFFENCE_SCHEDULE_MAPPING_S15_P1_LIFE = OffenceScheduleMapping(
+      offence = BASE_OFFENCE.copy(maxPeriodIsLife = true, startDate = BEFORE_SDS_LIST_A_CUT_OFF_DATE),
+      schedulePart = SCHEDULE_15_PART_1,
+      paragraphNumber = "65",
+    )
+    private val OFFENCE_SCHEDULE_MAPPING_S15_P1_LIFE_AFTER_CUTOFF = OffenceScheduleMapping(
+      offence = BASE_OFFENCE.copy(maxPeriodIsLife = true),
+      schedulePart = SCHEDULE_15_PART_1,
+      paragraphNumber = "65",
+    )
+  }
+}


### PR DESCRIPTION
I've left caching to be just in memory rather than using Redis. The way the endpoints are implemented means that the database work (which we avoid with caching), is not at an offence level, so it would be pointless to move the cache to redis, without re-writing the endpoints entirely